### PR TITLE
remove lint exceptions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {ContextPayload, PayloadHeader} from './types'
@@ -59,9 +58,11 @@ const getContextPayload = (ctx: Context): ContextPayload => {
       ctx.eventName === 'pull_request_target') &&
     (ctx.payload.action === 'opened' || ctx.payload.action === 'reopened')
   ) {
+    const text = ctx.payload.pull_request ? ctx.payload.pull_request.title : ''
+
     return {
       title: `Pull request ${ctx.payload.action}`,
-      text: ctx.payload.pull_request!.title,
+      text,
       ...factSection([senderFact(ctx), repositoryFact(ctx)]),
       ...urlSection([repoUrl(ctx), pullRequestUrl(ctx)])
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   ContextPayload,
   NameUrl,
@@ -46,15 +45,26 @@ export const headCommitFact = (ctx: Context): NameValue => ({
   value: ctx.payload['workflow_run'].head_commit.message
 })
 
-export const repoUrl = (ctx: Context): NameUrl => ({
-  name: 'Repository',
-  url: ctx.payload.repository!.html_url!
-})
+export const repoUrl = (ctx: Context): NameUrl => {
+  if (!ctx.payload.repository || !ctx.payload.repository.html_url) {
+    throw new Error('Could not determine repoUrl')
+  }
+  return {
+    name: 'Repository',
+    url: ctx.payload.repository.html_url
+  }
+}
 
-export const pullRequestUrl = (ctx: Context): NameUrl => ({
-  name: 'Pull Request',
-  url: ctx.payload.pull_request!.html_url!
-})
+export const pullRequestUrl = (ctx: Context): NameUrl => {
+  if (!ctx.payload.pull_request || !ctx.payload.pull_request.html_url) {
+    throw new Error('Could not determine pullRequestUrl')
+  }
+
+  return {
+    name: 'Pull Request',
+    url: ctx.payload.pull_request.html_url
+  }
+}
 
 export const workflowRunUrl = (ctx: Context): NameUrl => ({
   name: 'Workflow Run',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,11 @@ export const headCommitFact = (ctx: Context): NameValue => ({
 })
 
 export const repoUrl = (ctx: Context): NameUrl => {
-  if (!ctx.payload.repository || !ctx.payload.repository.html_url) {
+  if (
+    typeof ctx.payload.repository !== 'object' ||
+    ctx.payload.repository === null ||
+    typeof ctx.payload.repository.html_url !== 'string'
+  ) {
     throw new Error('Could not determine repoUrl')
   }
   return {
@@ -56,7 +60,11 @@ export const repoUrl = (ctx: Context): NameUrl => {
 }
 
 export const pullRequestUrl = (ctx: Context): NameUrl => {
-  if (!ctx.payload.pull_request || !ctx.payload.pull_request.html_url) {
+  if (
+    typeof ctx.payload.pull_request !== 'object' ||
+    ctx.payload.pull_request === null ||
+    typeof ctx.payload.pull_request.html_url !== 'string'
+  ) {
     throw new Error('Could not determine pullRequestUrl')
   }
 


### PR DESCRIPTION
It is theoretically dangerous to use non-null-assertions. It is better to throw if we get some undefined or null