### PR TITLE
make workflow_run notifications configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
         with:
           webhook_url: ${{ secrets.MSTEAMS_WEBHOOK_URL }}
           workflow_run_success: true # default is true
-          workflow_run_failure: false # default is true
+          workflow_run_failure: true # default is true
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Supported events:
   workflow_run
     types: [completed]
 
-  (The notification will be sent on both: success and failure conclusions.)
+  (The notification will be sent by default on both: success and failure conclusions.)
   ```
+
+You can set the options workflow_run_success and workflow_run_failure to false to disable the notification. E.g. if you want to only get notifications on failures, set workflow_run_success to false. 
 
 All of the supported events can be configured in a single workflow.
 
@@ -48,6 +50,8 @@ jobs:
         uses: metro-digital/ms-teams-notification-action@v1.0.0
         with:
           webhook_url: ${{ secrets.MSTEAMS_WEBHOOK_URL }}
+          workflow_run_success: true # default is true
+          workflow_run_failure: false # default is true
 ```
 
 ## License

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,28 +55,26 @@ async function run(): Promise<void> {
 }
 
 const getConfig = (): Config => {
-  const webhook_url = core.getInput('webhook_url')
-
-  const workflow_run_conclusion: ('success' | 'failure')[] = []
+  const result: Config = {
+    webhook_url: core.getInput('webhook_url'),
+    workflow_run_conclusion: []
+  }
 
   if (
     [false, 'false'].includes(core.getInput('workflow_run_success'))
       ? false
       : true
   ) {
-    workflow_run_conclusion.push('success')
+    result.workflow_run_conclusion.push('success')
   }
   if (
     [false, 'false'].includes(core.getInput('workflow_run_failure'))
       ? false
       : true
   ) {
-    workflow_run_conclusion.push('failure')
+    result.workflow_run_conclusion.push('failure')
   }
-  return {
-    webhook_url,
-    workflow_run_conclusion
-  }
+  return result
 }
 
 const getContextPayload = (ctx: Context, config: Config): ContextPayload => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,10 +59,18 @@ const getConfig = (): Config => {
 
   const workflow_run_conclusion: ('success' | 'failure')[] = []
 
-  if (core.getInput('workflow_run_success') ?? true) {
+  if (
+    [false, 'false'].includes(core.getInput('workflow_run_success'))
+      ? false
+      : true
+  ) {
     workflow_run_conclusion.push('success')
   }
-  if (core.getInput('workflow_run_failure') ?? true) {
+  if (
+    [false, 'false'].includes(core.getInput('workflow_run_failure'))
+      ? false
+      : true
+  ) {
     workflow_run_conclusion.push('failure')
   }
   return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,7 +99,9 @@ const getContextPayload = (ctx: Context, config: Config): ContextPayload => {
 
   if (
     ctx.eventName === 'workflow_run' &&
-    config.workflow_run_conclusion.includes(ctx.payload['workflow_run'])
+    config.workflow_run_conclusion.includes(
+      ctx.payload['workflow_run'].conclusion
+    )
   ) {
     return {
       title: `Workflow ${ctx.payload['workflow_run'].conclusion}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,8 @@ export type PotentialAction = {
     targets: ActionTarget[]
   }[]
 }
+
+export type Config = {
+  webhook_url: string
+  workflow_run_conclusion: ('success' | 'failure')[]
+}


### PR DESCRIPTION
This PR adds the input `workflow_run_success` and `workflow_run_failure`.

Motivation: 
Imagine you have 3000 repos and want to get notified if a workflow fails. Currently you would get bombarded also with successful workflow_run notifcations. This PR aims to make it configurable if succeeded or failed workflow runs should create notifications. By configuring workflow_run_success to false it would reduce the notifications to only failed runs.

I could not test it. Needs manual testing. 