### PR TITLE
fix: deprecated ms-teams integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.6.0",
         "@actions/github": "^5.0.0",
-        "ms-teams-webhook": "^1.0.4"
+        "ms-teams-webhook": "^2.0.0"
       },
       "devDependencies": {
         "@types/node": "^16.10.5",
@@ -1999,9 +1999,9 @@
       "dev": true
     },
     "node_modules/ms-teams-webhook": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ms-teams-webhook/-/ms-teams-webhook-1.0.4.tgz",
-      "integrity": "sha512-QyKoAq9FNwRSyw4Ww5h8OaOx+YQUsRyMOQu/jKsHFS9ITe4URXDF9rAbnndmTfy61CdzLsUCRzsPDlkzrecqcQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms-teams-webhook/-/ms-teams-webhook-2.0.0.tgz",
+      "integrity": "sha512-QggbQ2uG1O8hoQmNdx3B5rjZhku/Sb9kmD2h0yRpaQFToR579FBL2iO1iZZVEFN8wCbAkpFORAPKUfmNbD9sTw==",
       "dependencies": {
         "axios": "^0.21.1"
       }
@@ -4199,9 +4199,9 @@
       "dev": true
     },
     "ms-teams-webhook": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ms-teams-webhook/-/ms-teams-webhook-1.0.4.tgz",
-      "integrity": "sha512-QyKoAq9FNwRSyw4Ww5h8OaOx+YQUsRyMOQu/jKsHFS9ITe4URXDF9rAbnndmTfy61CdzLsUCRzsPDlkzrecqcQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms-teams-webhook/-/ms-teams-webhook-2.0.0.tgz",
+      "integrity": "sha512-QggbQ2uG1O8hoQmNdx3B5rjZhku/Sb9kmD2h0yRpaQFToR579FBL2iO1iZZVEFN8wCbAkpFORAPKUfmNbD9sTw==",
       "requires": {
         "axios": "^0.21.1"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@actions/core": "^1.6.0",
     "@actions/github": "^5.0.0",
-    "ms-teams-webhook": "^1.0.4"
+    "ms-teams-webhook": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^16.10.5",

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ async function run(): Promise<void> {
     }
 
     const client = new IncomingWebhook(config.webhook_url)
-    const response = await client.send(JSON.stringify(payload))
+    const response = await client.send(payload)
 
     if (!response?.text) {
       core.info(JSON.stringify(payload, null, 2))


### PR DESCRIPTION
The `ms-teams-webhook` is outdated and should be updated to 2.0.0.